### PR TITLE
Implement Node.js word frequency script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ phrases, then uploads the results as a CRM Analytics dataset or writes them to C
    npm install
    ```
 
-2. Set Salesforce credentials as environment variables:
+2. Set Salesforce credentials for JWT authorization using environment variables:
 
-   - `SF_USERNAME` – Salesforce username
-   - `SF_PASSWORD` – password concatenated with security token
-   - `SF_LOGIN_URL` – optional login URL (`https://login.salesforce.com` by default)
+   - `SFDC_CLIENT_ID` – connected app consumer key
+   - `SFDC_USERNAME` – Salesforce username
+   - `SFDC_LOGIN_URL` – login URL (`https://login.salesforce.com` by default)
+   - Place your private key in `jwt.key` or set `SFDC_JWT_KEY` to its path
+
+The script invokes `sfdcAuthorizer.js` to obtain an OAuth access token which is
+cached in `tmp/access_token.txt`.
 
 ## Usage
 
@@ -36,8 +40,9 @@ Without the `--csv` option the script attempts to upload a dataset named
 ## Example
 
 ```bash
-SF_USERNAME=myuser SF_PASSWORD=mypass node word_frequency.js \
-  -f Description__c,Notes__c -d My_Dataset --csv output.csv
+SFDC_CLIENT_ID=abc123 SFDC_USERNAME=myuser \
+  node word_frequency.js -f Description__c,Notes__c \
+  -d My_Dataset --csv output.csv
 ```
 
 This command queries the specified fields, parses each record, and stores the

--- a/word_frequency.js
+++ b/word_frequency.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+const { Command } = require('commander');
+const jsforce = require('jsforce');
+const fs = require('fs');
+const zlib = require('zlib');
+const { stringify } = require('csv-stringify/sync');
+const authorize = require('./sfdcAuthorizer');
+
+const program = new Command();
+program
+  .requiredOption('-f, --fields <fields>', 'comma separated fields to parse')
+  .requiredOption('-d, --dataset <dataset>', 'CRM Analytics dataset API name')
+  .option('--case-id <id>', 'filter by Case Id')
+  .option('--csv <file>', 'write output to CSV instead of CRM Analytics')
+  .parse(process.argv);
+
+const options = program.opts();
+const FIELDS = options.fields.split(',').map(f => f.trim()).filter(Boolean);
+
+function addWord(map, word, field, type, caseId) {
+  if (!word) return;
+  const key = `${field}|${word}`;
+  if (!map[key]) {
+    map[key] = { word, field, type, caseIds: new Set() };
+  }
+  map[key].caseIds.add(caseId);
+}
+
+function parseText(text, field, caseId, map) {
+  if (!text) return;
+  let cleaned = text.replace(/(<[^>]+>)/g, '').toLowerCase();
+  cleaned = cleaned.replace(/\n/g, '.');
+  cleaned = ` ${cleaned} `;
+
+  const phrase3 = /[\W](?:[\w%:]+\W){3}/g;
+  let match;
+  while ((match = phrase3.exec(cleaned)) !== null) {
+    const phrase = cleaned.substring(match.index + 1, match.index + match[0].length - 1);
+    addWord(map, phrase, field, 'Phrase', caseId);
+  }
+
+  const phrase2 = /[\W](?:[\w%:]+\W){2}/g;
+  while ((match = phrase2.exec(cleaned)) !== null) {
+    const phrase = cleaned.substring(match.index + 1, match.index + match[0].length - 1);
+    addWord(map, phrase, field, 'Phrase', caseId);
+  }
+
+  const single = /[\W](?:[\w%:]+\W)/g;
+  while ((match = single.exec(cleaned)) !== null) {
+    const word = cleaned.substring(match.index + 1, match.index + match[0].length - 1);
+    addWord(map, word, field, 'Word', caseId);
+  }
+}
+
+async function getDatasetId(conn, name) {
+  const url = `/services/data/v60.0/wave/datasets?q=${encodeURIComponent(name)}`;
+  const res = await conn.request(url);
+  for (const ds of res.datasets || []) {
+    if (ds.name === name) {
+      return `${ds.id}/${ds.currentVersionId}`;
+    }
+  }
+  throw new Error(`Dataset ${name} not found`);
+}
+
+async function fetchRecords(conn) {
+  const datasetId = await getDatasetId(conn, options.dataset);
+  let saql = `q = load \"${datasetId}\";`;
+  if (options.caseId) {
+    saql += ` q = filter q by 'Id' == \"${options.caseId}\";`;
+  }
+  saql += ` q = foreach q generate Id${FIELDS.map(f => `, '${f}'`).join('')};`;
+  const body = { query: saql };
+  const result = await conn.request({
+    method: 'POST',
+    url: `/services/data/v60.0/wave/query`,
+    body,
+    headers: { 'Content-Type': 'application/json' }
+  });
+  return result.results.records;
+}
+
+function buildDatasetArray(map) {
+  const dataset = [];
+  for (const key of Object.keys(map)) {
+    const k = map[key];
+    for (const id of k.caseIds) {
+      dataset.push({ Field: k.field, Type: k.type, Word: k.word, CaseId: id });
+    }
+  }
+  return dataset;
+}
+
+async function uploadDataset(conn, records) {
+  const csv = stringify(records, { header: true });
+  const gz = zlib.gzipSync(Buffer.from(csv));
+  const encoded = gz.toString('base64');
+
+  const metadata = {
+    fileFormat: { charsetName: 'UTF-8', fieldsDelimitedBy: ',', linesTerminatedBy: '\r\n' },
+    objects: [{
+      connector: 'CSV',
+      fullyQualifiedName: 'WordFrequency',
+      label: 'WordFrequency',
+      name: 'WordFrequency',
+      fields: [
+        { fullyQualifiedName: 'Field', name: 'Field', type: 'Text', label: 'Field' },
+        { fullyQualifiedName: 'Type', name: 'Type', type: 'Text', label: 'Type' },
+        { fullyQualifiedName: 'Word', name: 'Word', type: 'Text', label: 'Word' },
+        { fullyQualifiedName: 'CaseId', name: 'CaseId', type: 'Text', label: 'CaseId' }
+      ]
+    }]
+  };
+
+  const body = {
+    datasetName: 'Word_Frequency_File',
+    datasetLabel: 'Word Frequency (File)',
+    operation: 'Overwrite',
+    metadataJson: JSON.stringify(metadata),
+    data: encoded
+  };
+
+  await conn.request({
+    method: 'POST',
+    url: `/services/data/v60.0/wave/datasets`,
+    body,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+async function main() {
+  authorize();
+  const conn = new jsforce.Connection({
+    instanceUrl: process.env.SF_INSTANCE_URL,
+    accessToken: process.env.SF_ACCESS_TOKEN
+  });
+
+  const records = await fetchRecords(conn);
+  const map = {};
+  for (const rec of records) {
+    for (const f of FIELDS) {
+      parseText(rec[f], f, rec.Id, map);
+    }
+  }
+
+  const dataset = buildDatasetArray(map);
+
+  if (options.csv) {
+    fs.writeFileSync(options.csv, stringify(dataset, { header: true }));
+  } else {
+    await uploadDataset(conn, dataset);
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- implement Node version of Word Frequency
- authenticate using JWT via `sfdcAuthorizer.js`
- document JWT setup in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68820dc0f2dc8327a275b16e4c140e5f