### PR TITLE
Fix SF token not set after JWT login

### DIFF
--- a/sfdcAuthorizer.js
+++ b/sfdcAuthorizer.js
@@ -79,6 +79,8 @@ function authorize() {
     if (info.instanceUrl) {
       process.env.SF_INSTANCE_URL = info.instanceUrl;
     }
+    // expose the newly acquired token to child processes
+    process.env.SF_ACCESS_TOKEN = token;
 
     // 3) Ensure tmp directory exists
     const tmpDir = path.resolve(process.cwd(), "tmp");


### PR DESCRIPTION
## Summary
- ensure sfdcAuthorizer updates `SF_ACCESS_TOKEN` env var when a new token is acquired

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882133d5ad88327a71e1aa96293e4cc