### PR TITLE
Improve session refresh with jsforce

### DIFF
--- a/word_frequency.js
+++ b/word_frequency.js
@@ -59,8 +59,15 @@ async function requestWithRetry(conn, opts, retry = true) {
     if (retry && err && err.errorCode === 'INVALID_SESSION_ID') {
       console.log('ℹ Session expired, reauthorizing...');
       authorize();
-      conn.instanceUrl = process.env.SF_INSTANCE_URL;
-      conn.accessToken = process.env.SF_ACCESS_TOKEN;
+      if (typeof conn._establish === 'function') {
+        conn._establish({
+          instanceUrl: process.env.SF_INSTANCE_URL,
+          accessToken: process.env.SF_ACCESS_TOKEN
+        });
+      } else {
+        conn.instanceUrl = process.env.SF_INSTANCE_URL;
+        conn.accessToken = process.env.SF_ACCESS_TOKEN;
+      }
       return requestWithRetry(conn, opts, false);
     }
     throw err;


### PR DESCRIPTION
## Summary
- reestablish jsforce connection when session expires

## Testing
- `npm test`
- `node --check word_frequency.js`


------
https://chatgpt.com/codex/tasks/task_e_68821b9418548327b6f11daf4d3e0ff3