### PR TITLE
Use new JWT auth module

### DIFF
--- a/word_frequency.js
+++ b/word_frequency.js
@@ -4,7 +4,8 @@ const jsforce = require('jsforce');
 const fs = require('fs');
 const zlib = require('zlib');
 const { stringify } = require('csv-stringify/sync');
-const authorize = require('./sfdcAuthorizer');
+// Use JWT-based Salesforce authentication
+const authorize = require('./sfdcJwtAuth');
 
 const program = new Command();
 program


### PR DESCRIPTION
## Summary
- use `sfdcJwtAuth.js` instead of the old authorizer in `word_frequency.js`

## Testing
- `npm install`
- `node word_frequency.js --help`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68868515ab088327991adfa30f6b449a