### PR TITLE
Enable paging when searching for datasets

### DIFF
--- a/word_frequency.js
+++ b/word_frequency.js
@@ -86,12 +86,15 @@ async function requestWithRetry(conn, opts, retry = true) {
 }
 
 async function getDatasetId(conn, name) {
-  const url = `/services/data/v60.0/wave/datasets?q=${encodeURIComponent(name)}`;
-  const res = await requestWithRetry(conn, url);
-  for (const ds of res.datasets || []) {
-    if (ds.name === name) {
-      return `${ds.id}/${ds.currentVersionId}`;
+  let url = `/services/data/v60.0/wave/datasets?q=${encodeURIComponent(name)}`;
+  while (url) {
+    const res = await requestWithRetry(conn, url);
+    for (const ds of res.datasets || []) {
+      if (ds.name === name) {
+        return `${ds.id}/${ds.currentVersionId}`;
+      }
     }
+    url = res.nextPageUrl || null;
   }
   throw new Error(`Dataset ${name} not found`);
 }


### PR DESCRIPTION
## Summary
- page through dataset list when searching for dataset ID

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68875361018c8327aaa9e3e491878a3e