### PR TITLE
Deprecate Phrase output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Options:
 Without the `--csv` option the script attempts to upload a dataset named
 `Word_Frequency_File` to CRM Analytics using the REST API.
 
+The generated dataset now only includes individual words. The old `Phrase`
+type has been deprecated, so output records contain the columns `Field`,
+`Word`, and `CaseId`.
+
 ## Example
 
 ```bash

--- a/word_frequency.js
+++ b/word_frequency.js
@@ -24,11 +24,11 @@ let ID_FIELD = options.idField;
 const FOLDER_ID = options.folderId || process.env.SF_FOLDER_ID;
 const SEGMENT_FIELD = options.segment;
 
-function addWord(map, word, field, type, caseId) {
+function addWord(map, word, field, caseId) {
   if (!word) return;
   const key = `${field}|${word}`;
   if (!map[key]) {
-    map[key] = { word, field, type, caseIds: new Set() };
+    map[key] = { word, field, caseIds: new Set() };
   }
   map[key].caseIds.add(caseId);
 }
@@ -43,7 +43,7 @@ function parseText(text, field, caseId, map) {
   let match;
   while ((match = single.exec(cleaned)) !== null) {
     const word = cleaned.substring(match.index + 1, match.index + match[0].length - 1);
-    addWord(map, word, field, 'Word', caseId);
+    addWord(map, word, field, caseId);
   }
 }
 
@@ -143,7 +143,7 @@ function buildDatasetArray(map) {
   for (const key of Object.keys(map)) {
     const k = map[key];
     for (const id of k.caseIds) {
-      dataset.push({ Field: k.field, Type: k.type, Word: k.word, CaseId: id });
+      dataset.push({ Field: k.field, Word: k.word, CaseId: id });
     }
   }
   return dataset;
@@ -164,7 +164,6 @@ async function uploadDataset(conn, records) {
       name: 'WordFrequency',
       fields: [
         { fullyQualifiedName: 'Field', name: 'Field', type: 'Text', label: 'Field' },
-        { fullyQualifiedName: 'Type', name: 'Type', type: 'Text', label: 'Type' },
         { fullyQualifiedName: 'Word', name: 'Word', type: 'Text', label: 'Word' },
         { fullyQualifiedName: 'CaseId', name: 'CaseId', type: 'Text', label: 'CaseId' }
       ]


### PR DESCRIPTION
## Summary
- remove references to phrase parsing in `word_frequency.js`
- adjust dataset schema to only output words
- document the change in `README`

## Testing
- `node --check word_frequency.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688768beca6083279ed58318a978f46a